### PR TITLE
Fix Duplicate clients

### DIFF
--- a/fineract-core/src/main/java/org/apache/fineract/useradministration/domain/AppUserClientMapping.java
+++ b/fineract-core/src/main/java/org/apache/fineract/useradministration/domain/AppUserClientMapping.java
@@ -18,7 +18,6 @@
  */
 package org.apache.fineract.useradministration.domain;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -30,11 +29,11 @@ import org.apache.fineract.portfolio.client.domain.Client;
 @Table(name = "m_selfservice_user_client_mapping")
 public class AppUserClientMapping extends AbstractPersistableCustom<Long> {
 
-    @ManyToOne(optional = false, cascade = CascadeType.ALL)
+    @ManyToOne(optional = false)
     @JoinColumn(name = "appuser_id", nullable = false)
     private AppUser appUser;
 
-    @ManyToOne(optional = false, cascade = CascadeType.PERSIST)
+    @ManyToOne(optional = false)
     @JoinColumn(name = "client_id", nullable = false)
     private Client client;
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/AuditorAwareImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/core/domain/AuditorAwareImpl.java
@@ -35,7 +35,7 @@ public class AuditorAwareImpl implements AuditorAware<Long> {
         final SecurityContext securityContext = SecurityContextHolder.getContext();
         if (securityContext != null) {
             final Authentication authentication = securityContext.getAuthentication();
-            if (authentication != null) {
+            if (authentication != null && authentication.getPrincipal() instanceof AppUser) {
                 currentUserId = Optional.ofNullable(((AppUser) authentication.getPrincipal()).getId());
             } else {
                 currentUserId = retrieveSuperUser();


### PR DESCRIPTION
### 🐛 Bug Fix: Prevent Duplicate Client Creation in Self-Service Registration

#### Issue
In the self-service registration flow, creating a new app user was incorrectly attempting to create a duplicate client instead of linking to an existing one. This was due to the way **JPA (Java Persistence API) cascade types** were configured in the `AppUserClientMapping` entity.

**Root Cause:**
- The `AppUserClientMapping` entity had `CascadeType.PERSIST` on the `client` relationship.
- When creating a new app user, the system would instantiate an `AppUserClientMapping` to link the user with their client.
- Due to `CascadeType.PERSIST`, JPA attempted to **persist (create) a new client record**.
- This led to a **"Duplicate entry for account_no"** error because the client already existed.

#### 🔧 Solution
We removed both cascade types from the `AppUserClientMapping` entity:
- **Removed `CascadeType.ALL`** from the `appUser` relationship.
- **Removed `CascadeType.PERSIST`** from the `client` relationship.

**Now, when creating an `AppUserClientMapping`:**
- It will **not** automatically persist/update/delete the `AppUser` entity.
- It will **not** automatically persist/create a new `Client` entity.
- It will **only** establish the mapping between the existing user and existing client.

#### ✅ Why This Works
- The client is already created during the first API call in the self-service registration flow.
- When creating the app user, we only need to **link** it to the existing client.
- By removing the cascade types, JPA now only persists the mapping without trying to create new entities.
- This ensures proper relationships between users and clients while maintaining **data integrity**.

This fix prevents duplicate client creation and ensures the correct linkage between users and clients in the self-service registration process.


### 🐛 Bug Fix: Fix `ClassCastException` in `AuditorAwareImpl`

#### Issue
A **`ClassCastException`** occurred in the auditing process when retrieving the current authenticated user. The error message:

```
java.lang.ClassCastException: class java.lang.String cannot be cast to class org.apache.fineract.useradministration.domain.AppUser
```

**Root Cause:**
- The code assumed that `authentication.getPrincipal()` would always return an `AppUser` instance.
- However, in some cases, `getPrincipal()` was returning a `String`, leading to a `ClassCastException` when trying to cast it to `AppUser`.

#### 🔧 Solution
Added a type check to ensure `authentication.getPrincipal()` is an instance of `AppUser` before casting.

**Original Code:**
```java
final SecurityContext securityContext = SecurityContextHolder.getContext();
if (securityContext != null) {
    final Authentication authentication = securityContext.getAuthentication();
    if (authentication != null) {
        currentUserId = Optional.ofNullable(((AppUser) authentication.getPrincipal()).getId());
    } 
}
```

**Fixed Code:**
```java
final SecurityContext securityContext = SecurityContextHolder.getContext();
if (securityContext != null) {
    final Authentication authentication = securityContext.getAuthentication();
    if (authentication != null && authentication.getPrincipal() instanceof AppUser) {
        currentUserId = Optional.ofNullable(((AppUser) authentication.getPrincipal()).getId());
    } 
}
```

✅ **Why This Works**
- The new check `(authentication.getPrincipal() instanceof AppUser)` prevents invalid type casting.
- If `getPrincipal()` is not an instance of `AppUser`, the code simply skips the cast, avoiding the exception.
- Ensures smoother authentication handling without breaking the auditing process.