### PR TITLE
Fix/survey date type mismatch

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -300,6 +300,9 @@ jib {
         ports = ['8080/tcp', '8443/tcp']
         labels = [maintainer: 'Aleksandar Vidakovic <aleks@apache.org>']
         user = 'nobody:nogroup'
+        environment = [
+            'JAVA_TOOL_OPTIONS': ''
+        ]
     }
 
     allowInsecureRegistries = true

--- a/fineract-provider/src/main/java/org/apache/fineract/spm/domain/SurveyRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/spm/domain/SurveyRepository.java
@@ -18,7 +18,7 @@
  */
 package org.apache.fineract.spm.domain;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -27,11 +27,11 @@ import org.springframework.data.repository.query.Param;
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
 
     @Query("select s from Survey s where :pointInTime between s.validFrom and s.validTo")
-    List<Survey> fetchActiveSurveys(@Param("pointInTime") LocalDateTime pointInTime);
+    List<Survey> fetchActiveSurveys(@Param("pointInTime") LocalDate pointInTime);
 
     @Query("select s from Survey s ")
     List<Survey> fetchAllSurveys();
 
     @Query("select s from Survey s where s.key = :key and :pointInTime between s.validFrom and s.validTo")
-    Survey findByKey(@Param("key") String key, @Param("pointInTime") LocalDateTime pointInTime);
+    Survey findByKey(@Param("key") String key, @Param("pointInTime") LocalDate pointInTime);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/spm/service/SpmService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/spm/service/SpmService.java
@@ -44,7 +44,7 @@ public class SpmService {
     public List<Survey> fetchValidSurveys() {
         this.securityContext.authenticatedUser();
 
-        return this.surveyRepository.fetchActiveSurveys(DateUtils.getLocalDateTimeOfSystem());
+        return this.surveyRepository.fetchActiveSurveys(DateUtils.getLocalDateOfTenant());
     }
 
     public List<Survey> fetchAllSurveys() {
@@ -61,7 +61,7 @@ public class SpmService {
     public Survey createSurvey(final Survey survey) {
         this.securityContext.authenticatedUser();
         this.surveyValidator.validate(survey);
-        final Survey previousSurvey = this.surveyRepository.findByKey(survey.getKey(), DateUtils.getLocalDateTimeOfSystem());
+        final Survey previousSurvey = this.surveyRepository.findByKey(survey.getKey(), DateUtils.getLocalDateOfTenant());
 
         if (previousSurvey != null) {
             this.deactivateSurvey(previousSurvey.getId());


### PR DESCRIPTION
### **User description**
# Fix Survey Date Type Mismatch

## Issue
When attempting to create surveys through the web app, users encountered an exception due to a type mismatch between `LocalDateTime` and `LocalDate` in the survey validation query.

## Error
```
org.springframework.dao.InvalidDataAccessApiUsageException: You have attempted to set a value of type class java.time.LocalDateTime for parameter pointInTime with expected type of class java.time.LocalDate from query string select s from Survey s where s.key = :key and :pointInTime between s.validFrom and s.validTo.
```

## Fix
- Converted the `pointInTime` parameter from `LocalDateTime` to `LocalDate` before passing it to the query
- Ensured type consistency across the survey date validation logic


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed type mismatch in `SurveyRepository` methods by replacing `LocalDateTime` with `LocalDate`.

- Updated `SpmService` to use `DateUtils.getLocalDateOfTenant` for date handling.

- Ensured consistent date type usage across survey validation logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SurveyRepository.java</strong><dd><code>Adjusted date type in `SurveyRepository` methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fineract-provider/src/main/java/org/apache/fineract/spm/domain/SurveyRepository.java

<li>Replaced <code>LocalDateTime</code> with <code>LocalDate</code> in <code>fetchActiveSurveys</code> and <br><code>findByKey</code> methods.<br> <li> Updated query parameters to match the new date type.


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/fineract/pull/10/files#diff-3c70edf87ae17dae568410cc7f37ce9beffe9380c09e0e959c8b9997d0336ef5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SpmService.java</strong><dd><code>Updated `SpmService` to align with date type changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fineract-provider/src/main/java/org/apache/fineract/spm/service/SpmService.java

<li>Updated <code>fetchValidSurveys</code> and <code>createSurvey</code> methods to use <br><code>DateUtils.getLocalDateOfTenant</code>.<br> <li> Ensured compatibility with <code>SurveyRepository</code> changes.


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/fineract/pull/10/files#diff-de1267590ae9c7d550a94d542d76cb6fd04e1be5415e9aac9390d1826ea95f23">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>