### PR TITLE
FIX Loan Arrears SMS Campaign

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/sms/data/dto/SmsCampaignParamReq.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/campaigns/sms/data/dto/SmsCampaignParamReq.java
@@ -36,4 +36,6 @@ public class SmsCampaignParamReq implements Serializable {
     private Integer loanOfficerId;
     private Integer transactionId;
     private String reportName;
+    private Integer fromX;
+    private Integer toY;
 }


### PR DESCRIPTION

![Screen Shot 2025-06-16 at 13 14 28](https://github.com/user-attachments/assets/e68736a7-2948-455f-baf1-451d08415720)


PR: Fix Missing Parameters in SMS Campaign for Loan Arrears Report
 **Problem**
The **Loan in arrears** SMS campaign was failing due to unresolved SQL placeholders: `${fromX}` and `${toY}`.
These parameters, used to filter loans based on overdue periods, were missing from the input payload, causing the SQL to remain invalid and the report to break.

 **Solution**
This PR resolves the issue by updating the `SmsCampaignParamReq` DTO to include the missing fields:
* `fromX`
* `toY`
These parameters are now correctly passed into the report generation logic, allowing SQL substitution to complete successfully.
🔍 Technical Details
Updated class:
* `SmsCampaignParamReq.java`
Changes:
private Integer fromX;
private Integer toY;