### PR TITLE
 SMS Message Reports Error

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/api/SmsApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/api/SmsApiResource.java
@@ -91,16 +91,18 @@ public class SmsApiResource {
     public Page<SmsData> retrieveAllSmsByStatus(@PathParam("campaignId") final Long campaignId,
             @BeanParam SmsRequestParam smsRequestParam) {
         context.authenticatedUser().validateHasReadPermission(RESOURCE_NAME_FOR_PERMISSIONS);
-        final SearchParameters searchParameters = SearchParameters.builder().limit(smsRequestParam.limit()).offset(smsRequestParam.offset())
-                .orderBy(smsRequestParam.orderBy()).sortOrder(smsRequestParam.sortOrder()).build();
+        final SearchParameters searchParameters = SearchParameters.builder().limit(smsRequestParam.getLimit())
+                .offset(smsRequestParam.getOffset()).orderBy(smsRequestParam.getOrderBy()).sortOrder(smsRequestParam.getSortOrder())
+                .build();
 
-        final DateFormat dateFormat = Optional.ofNullable(smsRequestParam.rawDateFormat()).map(DateFormat::new).orElse(null);
-        final LocalDate fromDate = Optional.ofNullable(smsRequestParam.fromDate())
-                .map(fromDateParam -> fromDateParam.getDate(FROM_DATE_PARAM, dateFormat, smsRequestParam.locale())).orElse(null);
-        final LocalDate toDate = Optional.ofNullable(smsRequestParam.toDate())
-                .map(toDateParam -> toDateParam.getDate(TO_DATE_PARAM, dateFormat, smsRequestParam.locale())).orElse(null);
+        final DateFormat dateFormat = Optional.ofNullable(smsRequestParam.getRawDateFormat()).map(DateFormat::new).orElse(null);
+        final LocalDate fromDate = Optional.ofNullable(smsRequestParam.getFromDate())
+                .map(fromDateParam -> fromDateParam.getDate(FROM_DATE_PARAM, dateFormat, smsRequestParam.getLocale())).orElse(null);
+        final LocalDate toDate = Optional.ofNullable(smsRequestParam.getToDate())
+                .map(toDateParam -> toDateParam.getDate(TO_DATE_PARAM, dateFormat, smsRequestParam.getLocale())).orElse(null);
 
-        return readPlatformService.retrieveSmsByStatus(campaignId, searchParameters, smsRequestParam.status().intValue(), fromDate, toDate);
+        return readPlatformService.retrieveSmsByStatus(campaignId, searchParameters, smsRequestParam.getStatus().intValue(), fromDate,
+                toDate);
     }
 
     @PUT

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/param/SmsRequestParam.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/param/SmsRequestParam.java
@@ -18,8 +18,39 @@
  */
 package org.apache.fineract.infrastructure.sms.param;
 
+import jakarta.ws.rs.QueryParam;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.apache.fineract.infrastructure.core.api.DateParam;
 
-public record SmsRequestParam(Long status, DateParam fromDate, DateParam toDate, String locale, String rawDateFormat, Integer offset,
-        Integer limit, String orderBy, String sortOrder) {
+@Data
+@NoArgsConstructor
+public class SmsRequestParam {
+
+    @QueryParam("status")
+    private Long status;
+
+    @QueryParam("fromDate")
+    private DateParam fromDate;
+
+    @QueryParam("toDate")
+    private DateParam toDate;
+
+    @QueryParam("locale")
+    private String locale;
+
+    @QueryParam("dateFormat")
+    private String rawDateFormat;
+
+    @QueryParam("offset")
+    private Integer offset;
+
+    @QueryParam("limit")
+    private Integer limit;
+
+    @QueryParam("orderBy")
+    private String orderBy;
+
+    @QueryParam("sortOrder")
+    private String sortOrder;
 }


### PR DESCRIPTION
### **User description**
## Problem
When checking SMS messages reports for a campaign, the API returns a 500 Internal Server Error with the following details:

**Request:**
```
GET https://localhost:8443/fineract-provider/api/v1/sms/2/messageByStatus?status=100&locale=en&dateFormat=dd MMMM yyyy&fromDate=01 June 2025&toDate=17 June 2025
```

**Response:**
```json
{
  "timestamp": "2025-06-17T12:06:20.745Z",
  "status": 500,
  "error": "Internal Server Error",
  "path": "/fineract-provider/api/v1/sms/2/messageByStatus"
}
```

**Console Error:**
```
org.glassfish.hk2.api.MultiException: A MultiException has 2 exceptions. They are:
1. java.lang.NoSuchMethodException: Could not find a suitable constructor in org.apache.fineract.infrastructure.sms.param.SmsRequestParam class.
2. java.lang.IllegalArgumentException: Errors were discovered while reifying SystemDescriptor(...)
```

## Root Cause
This happened because:
1. **HK2 was trying to create an instance** of SmsRequestParam for dependency injection
2. **The class was a record** which requires all parameters in the constructor
3. **HK2 couldn't find a default constructor** to create the instance
4. **This caused the NoSuchMethodException**

## Why This Occurred
* **Jersey uses HK2** for dependency injection
* **@BeanParam annotation** tells Jersey to create an instance of the parameter class
* **Records in Java** don't have default constructors, they only have constructors that take all parameters
* **HK2 couldn't instantiate** the record class without knowing all the parameter values upfront

## Solution
The fix we implemented:
We converted the SmsRequestParam from a record to a regular class with:
* A default constructor for HK2 to use
* Getter and setter methods for JAX-RS parameter binding
* @QueryParam annotations to map HTTP query parameters to fields

This allowed HK2 to:
1. Create an instance using the default constructor
2. Populate the fields using the setter methods
3. Map the query parameters correctly


___

### **PR Type**
Bug fix


___

### **Description**
• Fix SMS message reports 500 error by converting record to class
• Add QueryParam annotations for proper JAX-RS parameter binding
• Update method calls to use getter methods instead of record accessors


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SmsRequestParam.java</strong><dd><code>Convert record to class with QueryParam annotations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/param/SmsRequestParam.java

• Convert record to regular class with @Data and @NoArgsConstructor <br>annotations<br> • Add @QueryParam annotations to all fields for JAX-RS <br>parameter binding<br> • Replace record constructor with default <br>constructor and getter/setter methods


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/fineract/pull/22/files#diff-986d3f71494ff624d67936a3f46f6ae02c8b214bcff977944a25d9a2d4e5c926">+33/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmsApiResource.java</strong><dd><code>Update method calls to use getter methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fineract-provider/src/main/java/org/apache/fineract/infrastructure/sms/api/SmsApiResource.java

• Update method calls from record accessor syntax to getter methods<br> • <br>Change <code>smsRequestParam.field()</code> to <code>smsRequestParam.getField()</code> pattern<br> • <br>Maintain same functionality with updated accessor pattern


</details>


  </td>
  <td><a href="https://github.com/truehostcloud/fineract/pull/22/files#diff-cbc0e90fb6ccb7170e9febf132f5e432ed56b66c76a5dbae79472dafb302a126">+10/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>